### PR TITLE
Fix inconsistency with the word preferences

### DIFF
--- a/src/BrowserLocalization.php
+++ b/src/BrowserLocalization.php
@@ -36,11 +36,11 @@ class BrowserLocalization implements LocalizationContract
      * @param array $locales
      * @param string $browserPreference
      */
-    public function __construct($locale = 'en-GB', array $locales = ['en-GB'], $browserPreference = '')
+    public function __construct($locale = 'en-GB', array $locales = ['en-GB'], $browserPreferences = '')
     {
         $this->default = $locale;
         $this->available = $locales;
-        $this->browserPreference = $browserPreference;
+        $this->browserPreferences = $browserPreference;
 
         return $this;
     }
@@ -112,7 +112,7 @@ class BrowserLocalization implements LocalizationContract
     {
 
         if ($preferences !== null) {
-            $this->browserPreference = $preferences;
+            $this->browserPreferences = $preferences;
         }
 
         $browserPreferences = explode(",", $this->browserPreference);


### PR DESCRIPTION
The code will always detect the default language without
this fix. Because it sometimes uses 'browserPreference' and sometimes 'browserPreferences'. Those are totaly different variables and are used as if they are the same.